### PR TITLE
Fix uninitialized pointer warning

### DIFF
--- a/maggiclient/src/base/moduleManager/modules/clicker/rightAutoClicker.cpp
+++ b/maggiclient/src/base/moduleManager/modules/clicker/rightAutoClicker.cpp
@@ -16,8 +16,8 @@ void RightAutoClicker::Update()
 	if (Menu::Open) return;
 	if (SDK::Minecraft->IsInGuiState()) return;
 
-	jclass blockClass;
-	Java::AssignClass("net.minecraft.item.ItemBlock", blockClass);
+        jclass blockClass = nullptr;
+        Java::AssignClass("net.minecraft.item.ItemBlock", blockClass);
 	if (SDK::Minecraft->thePlayer->GetInventory().GetCurrentItem().GetInstance() == NULL) return;
 	if (blocksOnly && !Java::Env->IsInstanceOf(SDK::Minecraft->thePlayer->GetInventory().GetCurrentItem().GetItem(), blockClass)) return;
 


### PR DESCRIPTION
## Summary
- fix uninitialized pointer in RightAutoClicker

## Testing
- `x86_64-w64-mingw32-g++ -c maggiclient/src/base/moduleManager/modules/clicker/rightAutoClicker.cpp -o /tmp/rightAutoClicker.o` *(fails: Windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686cf6a5b47c833388834b0601450e39