### PR TITLE
Fix ImGui ID stack issue and update ESP nametag

### DIFF
--- a/maggiclient/src/base/menu/renderMenu.cpp
+++ b/maggiclient/src/base/menu/renderMenu.cpp
@@ -97,6 +97,8 @@ void Menu::RenderMenu()
         ImGui::EndChild();
     }
 
+    ImGui::Columns(1); // properly close column set to avoid ID stack issues
+
     ImGui::PopID();
     ImGui::End();
 }

--- a/maggiclient/src/base/moduleManager/modules/visual/esp.cpp
+++ b/maggiclient/src/base/moduleManager/modules/visual/esp.cpp
@@ -244,7 +244,7 @@ void Esp::RenderUpdate()
                 }
                 else
                 {
-                    ImGui::GetWindowDrawList()->AddText(Menu::Font, TextSize, ImVec2(posX, posY), textColor, name);
+                    RenderQOLF::DrawShadowedText(Menu::Font, TextSize, ImVec2(posX, posY), textColor, name);
                 }
             }
 
@@ -261,7 +261,7 @@ void Esp::RenderUpdate()
             }
             else
             {
-                ImGui::GetWindowDrawList()->AddText(Menu::Font, distanceTextSize, ImVec2(posX, posY), textColor, distanceStr);
+                RenderQOLF::DrawShadowedText(Menu::Font, distanceTextSize, ImVec2(posX, posY), textColor, distanceStr);
             }
         }
     }

--- a/maggiclient/src/base/util/render/renderqolf.h
+++ b/maggiclient/src/base/util/render/renderqolf.h
@@ -6,12 +6,18 @@
 
 class RenderQOLF {
 public:
-	static void DrawOutlinedText(ImFont* font, float textSize, ImVec2 pos, ImColor color, ImColor outlineColor, const char* text) {
-		ImGui::GetWindowDrawList()->AddText(font, textSize, ImVec2(pos.x + 1, pos.y), outlineColor, text);
-		ImGui::GetWindowDrawList()->AddText(font, textSize, ImVec2(pos.x - 1, pos.y), outlineColor, text);
-		ImGui::GetWindowDrawList()->AddText(font, textSize, ImVec2(pos.x, pos.y + 1), outlineColor, text);
-		ImGui::GetWindowDrawList()->AddText(font, textSize, ImVec2(pos.x, pos.y - 1), outlineColor, text);
+        static void DrawOutlinedText(ImFont* font, float textSize, ImVec2 pos, ImColor color, ImColor outlineColor, const char* text) {
+                ImGui::GetWindowDrawList()->AddText(font, textSize, ImVec2(pos.x + 1, pos.y), outlineColor, text);
+                ImGui::GetWindowDrawList()->AddText(font, textSize, ImVec2(pos.x - 1, pos.y), outlineColor, text);
+                ImGui::GetWindowDrawList()->AddText(font, textSize, ImVec2(pos.x, pos.y + 1), outlineColor, text);
+                ImGui::GetWindowDrawList()->AddText(font, textSize, ImVec2(pos.x, pos.y - 1), outlineColor, text);
 
-		ImGui::GetWindowDrawList()->AddText(font, textSize, pos, color, text);
-	}
-};
+                ImGui::GetWindowDrawList()->AddText(font, textSize, pos, color, text);
+        }
+
+        // Draw text with a subtle shadow for a cleaner look
+        static void DrawShadowedText(ImFont* font, float textSize, ImVec2 pos, ImColor color, const char* text) {
+                ImColor shadow(0, 0, 0, 160);
+                ImGui::GetWindowDrawList()->AddText(font, textSize, ImVec2(pos.x + 1, pos.y + 1), shadow, text);
+                ImGui::GetWindowDrawList()->AddText(font, textSize, pos, color, text);
+        }};


### PR DESCRIPTION
## Summary
- fix `ImGui` assertion by closing the column set before ending the menu
- add `DrawShadowedText` helper
- use new shadowed text for nametag rendering when outline is disabled

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9fcbad2083338d64edb8b3d45803