### PR TITLE
Refactor lighten helper and silence getenv warnings

### DIFF
--- a/maggiclient/src/base/menu/hooks/wglSwapBuffers.cpp
+++ b/maggiclient/src/base/menu/hooks/wglSwapBuffers.cpp
@@ -15,6 +15,8 @@
 
 #include "../../base.h"
 
+static float lighten(float c, float amount) { return std::min(c + amount, 1.0f); }
+
 std::once_flag setupFlag;
 std::atomic_flag clipCursor = ATOMIC_FLAG_INIT;
 RECT originalClip;
@@ -151,26 +153,25 @@ void Menu::SetupImgui()
 	Menu::Font = io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\segoeui.ttf", 16);
 	Menu::FontBold = io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\segoeuib.ttf", 24);
 
-	ImVec4* colors = ImGui::GetStyle().Colors;
-	colors[ImGuiCol_Text] = ImVec4(1.f, 1.f, 1.f, 1.00f);
-	colors[ImGuiCol_TextDisabled] = ImVec4(0.35f, 0.35f, 0.35f, 1.00f);
-	colors[ImGuiCol_WindowBg] = ImVec4(0.045f, 0.045f, 0.045f, 0.90);
-	colors[ImGuiCol_ChildBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
-	colors[ImGuiCol_PopupBg] = ImVec4(0.08f, 0.08f, 0.08f, 0.94f);
-	colors[ImGuiCol_Border] = ImVec4(0.00f, 0.00f, 0.00f, 0.50f);
-	colors[ImGuiCol_BorderShadow] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
-	colors[ImGuiCol_FrameBg] = ImVec4(0.045f, 0.045f, 0.045f, 0.90);
-	colors[ImGuiCol_FrameBgHovered] = ImVec4(0.045f, 0.045f, 0.045f, 0.90);
-	colors[ImGuiCol_FrameBgActive] = ImVec4(0.045f, 0.045f, 0.045f, 0.90);
-	colors[ImGuiCol_TitleBg] = ImVec4(0.065f, 0.065f, 0.065f, 0.90);
-	colors[ImGuiCol_TitleBgActive] = ImVec4(0.065f, 0.065f, 0.065f, 0.90);
-	colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.065f, 0.065f, 0.065f, 0.90);
-	colors[ImGuiCol_MenuBarBg] = ImVec4(0.14f, 0.14f, 0.14f, 1.00f);
-        colors[ImGuiCol_ScrollbarBg] = ImVec4(0.02f, 0.02f, 0.02f, 0.00);
+        ImVec4* colors = ImGui::GetStyle().Colors;
+        colors[ImGuiCol_Text] = ImVec4(1.f, 1.f, 1.f, 1.00f);
+        colors[ImGuiCol_TextDisabled] = ImVec4(0.35f, 0.35f, 0.35f, 1.00f);
+        colors[ImGuiCol_WindowBg] = ImVec4(0.045f, 0.045f, 0.045f, 0.90f);
+        colors[ImGuiCol_ChildBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+        colors[ImGuiCol_PopupBg] = ImVec4(0.08f, 0.08f, 0.08f, 0.94f);
+        colors[ImGuiCol_Border] = ImVec4(0.00f, 0.00f, 0.00f, 0.50f);
+        colors[ImGuiCol_BorderShadow] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+        colors[ImGuiCol_FrameBg] = ImVec4(0.045f, 0.045f, 0.045f, 0.90f);
+        colors[ImGuiCol_FrameBgHovered] = ImVec4(0.045f, 0.045f, 0.045f, 0.90f);
+        colors[ImGuiCol_FrameBgActive] = ImVec4(0.045f, 0.045f, 0.045f, 0.90f);
+        colors[ImGuiCol_TitleBg] = ImVec4(0.065f, 0.065f, 0.065f, 0.90f);
+        colors[ImGuiCol_TitleBgActive] = ImVec4(0.065f, 0.065f, 0.065f, 0.90f);
+        colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.065f, 0.065f, 0.065f, 0.90f);
+        colors[ImGuiCol_MenuBarBg] = ImVec4(0.14f, 0.14f, 0.14f, 1.00f);
+        colors[ImGuiCol_ScrollbarBg] = ImVec4(0.02f, 0.02f, 0.02f, 0.00f);
         colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.31f, 0.31f, 0.31f, 1.00f);
         colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.41f, 0.41f, 0.41f, 1.00f);
         colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.51f, 0.51f, 0.51f, 1.00f);
-        auto lighten = [](float c, float amount) { return std::min(c + amount, 1.0f); };
         colors[ImGuiCol_CheckMark] = Menu::AccentColor;
         colors[ImGuiCol_SliderGrab] = Menu::AccentColor;
         colors[ImGuiCol_SliderGrabActive] = ImVec4(lighten(Menu::AccentColor.x, 0.1f), lighten(Menu::AccentColor.y, 0.1f), lighten(Menu::AccentColor.z, 0.1f), Menu::AccentColor.w);
@@ -180,7 +181,7 @@ void Menu::SetupImgui()
         colors[ImGuiCol_Header] = Menu::AccentColor;
         colors[ImGuiCol_HeaderHovered] = ImVec4(lighten(Menu::AccentColor.x, 0.1f), lighten(Menu::AccentColor.y, 0.1f), lighten(Menu::AccentColor.z, 0.1f), Menu::AccentColor.w);
         colors[ImGuiCol_HeaderActive] = ImVec4(lighten(Menu::AccentColor.x, 0.2f), lighten(Menu::AccentColor.y, 0.2f), lighten(Menu::AccentColor.z, 0.2f), Menu::AccentColor.w);
-        colors[ImGuiCol_Separator] = ImVec4(0.32f, 0.32f, 0.32f, 0.3);
+        colors[ImGuiCol_Separator] = ImVec4(0.32f, 0.32f, 0.32f, 0.3f);
         colors[ImGuiCol_SeparatorHovered] = ImVec4(0.32f, 0.32f, 0.32f, 1.00f);
         colors[ImGuiCol_SeparatorActive] = ImVec4(0.32f, 0.32f, 0.32f, 1.00f);
         colors[ImGuiCol_ResizeGrip] = ImVec4(1.00f, 1.00f, 1.00f, 0.85f);
@@ -189,23 +190,23 @@ void Menu::SetupImgui()
         colors[ImGuiCol_Tab] = Menu::AccentColor;
         colors[ImGuiCol_TabHovered] = ImVec4(lighten(Menu::AccentColor.x, 0.1f), lighten(Menu::AccentColor.y, 0.1f), lighten(Menu::AccentColor.z, 0.1f), Menu::AccentColor.w);
         colors[ImGuiCol_TabActive] = ImVec4(lighten(Menu::AccentColor.x, 0.2f), lighten(Menu::AccentColor.y, 0.2f), lighten(Menu::AccentColor.z, 0.2f), Menu::AccentColor.w);
-	colors[ImGuiCol_TabUnfocused] = ImVec4(0.05f, 0.05f, 0.05f, 0.90f);
-	colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.13f, 0.13f, 0.13f, 0.74f);
-	colors[ImGuiCol_PlotLines] = ImVec4(0.61f, 0.61f, 0.61f, 1.00f);
-	colors[ImGuiCol_PlotLinesHovered] = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
-	colors[ImGuiCol_PlotHistogram] = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
-	colors[ImGuiCol_PlotHistogramHovered] = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
-	colors[ImGuiCol_TableHeaderBg] = ImVec4(0.19f, 0.19f, 0.20f, 1.00f);
-	colors[ImGuiCol_TableBorderStrong] = ImVec4(0.31f, 0.31f, 0.35f, 1.00f);
-	colors[ImGuiCol_TableBorderLight] = ImVec4(0.23f, 0.23f, 0.25f, 1.00f);
-	colors[ImGuiCol_TableRowBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
-	colors[ImGuiCol_TableRowBgAlt] = ImVec4(1.00f, 1.00f, 1.00f, 0.07f);
-	colors[ImGuiCol_TextSelectedBg] = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
-	colors[ImGuiCol_DragDropTarget] = ImVec4(1.00f, 1.00f, 0.00f, 0.90f);
-	colors[ImGuiCol_NavHighlight] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
-	colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
-	colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
-	colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
+        colors[ImGuiCol_TabUnfocused] = ImVec4(0.05f, 0.05f, 0.05f, 0.90f);
+        colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.13f, 0.13f, 0.13f, 0.74f);
+        colors[ImGuiCol_PlotLines] = ImVec4(0.61f, 0.61f, 0.61f, 1.00f);
+        colors[ImGuiCol_PlotLinesHovered] = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
+        colors[ImGuiCol_PlotHistogram] = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+        colors[ImGuiCol_PlotHistogramHovered] = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
+        colors[ImGuiCol_TableHeaderBg] = ImVec4(0.19f, 0.19f, 0.20f, 1.00f);
+        colors[ImGuiCol_TableBorderStrong] = ImVec4(0.31f, 0.31f, 0.35f, 1.00f);
+        colors[ImGuiCol_TableBorderLight] = ImVec4(0.23f, 0.23f, 0.25f, 1.00f);
+        colors[ImGuiCol_TableRowBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+        colors[ImGuiCol_TableRowBgAlt] = ImVec4(1.00f, 1.00f, 1.00f, 0.07f);
+        colors[ImGuiCol_TextSelectedBg] = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
+        colors[ImGuiCol_DragDropTarget] = ImVec4(1.00f, 1.00f, 0.00f, 0.90f);
+        colors[ImGuiCol_NavHighlight] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+        colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
+        colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
+        colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
 
         ImGuiStyle& style = ImGui::GetStyle();
         style.WindowRounding = 10.0f;

--- a/maggiclient/src/base/menu/menu.cpp
+++ b/maggiclient/src/base/menu/menu.cpp
@@ -1,3 +1,4 @@
+#define _CRT_SECURE_NO_WARNINGS
 #include "menu.h"
 #include "../util/logger.h"
 #include "../../../ext/imgui/imgui.h"
@@ -8,6 +9,7 @@
 #include <filesystem>
 #include <sstream>
 #include <algorithm>
+#include <cstdlib>
 
 void Menu::Init()
 {

--- a/maggiclient/src/base/moduleManager/modules/settings/settings.cpp
+++ b/maggiclient/src/base/moduleManager/modules/settings/settings.cpp
@@ -1,11 +1,12 @@
-#include "settings.h"
 #define _CRT_SECURE_NO_WARNINGS
+#include "settings.h"
 #include "../../../../../ext/imgui/imgui.h"
 #include "../../../menu/menu.h" 
 #include <fstream>
 #include <iostream> 
-#include <sstream> 
+#include <sstream>
 #include <filesystem> // Für Dateisystemoperationen
+#include <cstdlib>
 #include "../../../moduleManager/modules/visual/esp.h" 
 #include "../../../moduleManager/modules/combat/reach.h" 
 #include "../../../moduleManager/modules/combat/aimassist.h" 


### PR DESCRIPTION
## Summary
- use shared `lighten` helper for ImGui color calculations
- ensure ImGui colors use float literals
- suppress MSVC warnings for `getenv`


------
https://chatgpt.com/codex/tasks/task_e_68a5bfe1a1748333823321f4cfe128e9